### PR TITLE
Move `limit` from url path to query params

### DIFF
--- a/src/core/oipd-api/daemonApi.js
+++ b/src/core/oipd-api/daemonApi.js
@@ -159,9 +159,9 @@ class DaemonApi {
 		try {
 			res = await this.index.get(`/artifact/search`, {
 				params: {
-					q: query
-				},
-				limit
+					q: query,
+					limit
+				}
 			})
 		} catch (err) {
 			throw new Error(`Failed to search artifacts for: ${query} -- ${err}`)
@@ -370,9 +370,10 @@ class DaemonApi {
 	async getLatestArtifacts(limit = 100, nsfw = false) {
 		let res
 		try {
-			res = await this.index.get(`/artifact/get/latest/${limit}`, {
+			res = await this.index.get(`/artifact/get/latest`, {
 				params: {
-					nsfw
+					nsfw,
+					limit
 				}
 			});
 		} catch (err) {
@@ -398,9 +399,10 @@ class DaemonApi {
 	async getLatest041Artifacts(limit = 100, nsfw = false) {
 		let res
 		try {
-			res = await this.index.get(`/oip041/artifact/get/latest/${limit}`, {
+			res = await this.index.get(`/oip041/artifact/get/latest`, {
 				params: {
-					nsfw
+					nsfw,
+					limit
 				}
 			});
 		} catch (err) {
@@ -478,9 +480,10 @@ class DaemonApi {
 	async getLatest042Artifacts(limit = 100, nsfw = false) {
 		let res
 		try {
-			res = await this.index.get(`/oip042/artifact/get/latest/${limit}`, {
+			res = await this.index.get(`/oip042/artifact/get/latest`, {
 				params: {
-					nsfw
+					nsfw,
+					limit
 				}
 			});
 		} catch (err) {
@@ -506,9 +509,10 @@ class DaemonApi {
 	async getLatestAlexandriaMediaArtifacts(limit = 100, nsfw = false) {
 		let res
 		try {
-			res = await this.index.get(`/alexandria/artifact/get/latest/${limit}`, {
+			res = await this.index.get(`/alexandria/artifact/get/latest`, {
 				params: {
-					nsfw
+					nsfw,
+					limit
 				}
 			});
 		} catch (err) {
@@ -669,9 +673,12 @@ class DaemonApi {
 	async getMultiparts(ref, limit) {
 		let res;
 		let querystring = `/multipart/get/ref/${ref}`
-		if (limit) querystring += `/${limit}`
 		try {
-			res = await this.index.get(querystring)
+			res = await this.index.get(querystring,{
+				params: {
+					limit
+				}
+			})
 		} catch (err) {
 			throw new Error(`Failed to get multiparts by ref: ${ref} -- ${err}`)
 		}
@@ -723,7 +730,11 @@ class DaemonApi {
 	async getLastestHistorianData(limit = 100) {
 		let res
 		try {
-			res = await this.index.get(`historian/get/latest/${limit}`)
+			res = await this.index.get(`historian/get/latest`,{
+				params: {
+					limit
+				}
+			})
 		} catch (err) {
 			throw new Error(`Failed to get latest historian data: ${err}`)
 		}


### PR DESCRIPTION
API shifted at oipdaemon to ease addition of pagination

Can't merge until changes are first merged at the daemon and deployed to server