### PR TITLE
Fix logic to handle multiple outputs in ExplorerWallet.buildTXHex()

### DIFF
--- a/src/modules/wallets/ExplorerWallet.js
+++ b/src/modules/wallets/ExplorerWallet.js
@@ -175,28 +175,12 @@ class ExplorerWallet {
 
     inputs.forEach(input => txb.addInput(input.txId, input.vout))
 
-    // Check if we are paying to ourself, if so, merge the outputs to just a single output.
-    // Check if we have two outputs (i.e. pay to and change)
-    if (outputs.length === 2) {
-      // If the first input is sending to the from address, and there is a change output,
-      // then merge the outputs.
-      if (outputs[0].address === this.p2pkh && !outputs[1].address) {
-        let totalToSend = outputs[0].value + outputs[1].value
-        outputs = [{
-          address: this.p2pkh,
-          value: totalToSend
-        }]
-      } else {
-        // send the original amount to the first address and send the rest to yourself as change
-        if (outputs[0].address !== this.p2pkh && !outputs[1].address) {
-          outputs[1].address = this.p2pkh
-        }
-      }
-    }
+    // console.log(outputs)
 
     outputs.forEach(output => {
       if (!output.address) {
-        throw new Error(`Missing output address: ${outputs}`)
+        output.address = this.p2pkh
+        // throw new Error(`Missing output address: ${outputs}`)
       }
       txb.addOutput(output.address, output.value)
     })
@@ -209,7 +193,7 @@ class ExplorerWallet {
     }
 
     let builtHex
-
+    // console.log('txb:', txb)
     try {
       builtHex = txb.build().toHex()
     } catch (err) {

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -734,10 +734,10 @@ class RPCWallet {
 
     // If we do not already have a loop going to make sure confirmations get fired off, create one
     if (!this.onConfirmationInterval) {
-      this.onConfirmationInterval = setInterval((async () => { 
+      this.onConfirmationInterval = setInterval(async () => {
         await this.checkAncestorCount(true)
-        await this.checkForConfirmations() 
-      }).bind(this), CONFIRMATION_CHECK_LENGTH)
+        await this.checkForConfirmations()
+      }, CONFIRMATION_CHECK_LENGTH)
     }
   }
 
@@ -746,13 +746,13 @@ class RPCWallet {
    * @return {Promise} Returns a promise that resolves once all of the available confirmation callbacks have been run
    */
   async checkForConfirmations () {
-    if (this.getConfirmationSubscriptionCount() === 0) { 
+    if (this.getConfirmationSubscriptionCount() === 0) {
       // Sanity check to clear out the interval if for whatever reason it currently exists.
       if (this.onConfirmationInterval) {
         clearInterval(this.onConfirmationInterval)
         this.onConfirmationInterval = undefined
       }
-      return 
+      return
     }
 
     console.log(`[RPC Wallet] Checking ${this.getConfirmationSubscriptionCount()} transations for confirmations...`)

--- a/test/integration/modules/wallets/ExplorerWallet.test.js
+++ b/test/integration/modules/wallets/ExplorerWallet.test.js
@@ -56,20 +56,42 @@ describe(`ExplorerWallet`, () => {
     //  }
     //  done()
     // }, 250 * 100 * 100)
-    it.skip('build and broadcast TX hex | sendDataToChain', async () => {
+    it('build and broadcast TX hex | sendDataToChain', async () => {
       let wallet = new ExplorerWallet({ wif, network: 'testnet' })
       let txid = await wallet.sendDataToChain(`RC`)
       expect(typeof txid === 'string').toBeTruthy()
       // console.log(txid)
     })
-    it.skip('flotx w custom output | sendTx', async () => {
-      let wallet = new ExplorerWallet(wif, 'testnet')
+    it('flotx w custom output | sendTx', async () => {
+      let wallet = new ExplorerWallet({ wif, network: 'testnet' })
       let output = {
         address: 'oNAydz5TjkhdP3RPuu3nEirYQf49Jrzm4S',
         value: Math.floor(0.0001 * floTestnet.satPerCoin)
       }
       let txid = await wallet.sendTx(output, 'to testnet')
       // console.log(txid)
+      expect(txid).toBeDefined()
+      expect(typeof txid === 'string').toBeTruthy()
+    })
+    it('flotx w multiple custom output | sendTx', async () => {
+      jest.setTimeout(10000)
+      let wallet = new ExplorerWallet({ wif, network: 'testnet' })
+      let outputs = [
+        {
+          address: 'oNAydz5TjkhdP3RPuu3nEirYQf49Jrzm4S',
+          value: Math.floor(0.0001 * floTestnet.satPerCoin)
+        },
+        {
+          address: 'ofbB67gqjgaYi45u8Qk2U3hGoCmyZcgbN4',
+          value: Math.floor(0.0001 * floTestnet.satPerCoin)
+        },
+        {
+          address: 'oV5qwoq9CSaXersHk4DQVHhoMTDjRNWRF2',
+          value: Math.floor(0.0001 * floTestnet.satPerCoin)
+        }
+      ]
+      let txid = await wallet.sendTx(outputs, 'to testnet')
+      console.log(txid)
       expect(txid).toBeDefined()
       expect(typeof txid === 'string').toBeTruthy()
     })


### PR DESCRIPTION
## Motivation
Allow ExplorerWallet.sendTx() to handle multiple outputs

## What did I do?
1) I removed a logic to manually handle outputs and change. 
It seemed unnecessary since the `bitcoinjs-lib` appears to handle messy outputs just fine.

2) I removed an Error thrown if among the `outputs` from `buildInputsAndOutputs()` an output had no `address`.
It seems that `buildInputsAndOutputs` will always pass the "change" output without an `address` attribute.
This was fixed for transactions with only one output by the logic I removed above but it fails with multiple outputs.
Instead, I add the p2pkh address to the "change" and removed the error.

3) I added tests for multiple outputs transaction in the `integration` test suite.
I made sure previous tests that seem to use this logic still passes.

4) I also ran `npm run code-format` which made the other change in the code that is unrelated to this PR - but it makes the `npm test` pass now.