### PR TITLE
ACTUM-343: Ancestor count & rebroadcasting fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1690,23 +1690,6 @@
             "bufio": "~1.0.6",
             "loady": "~0.0.1",
             "nan": "^2.14.0"
-          },
-          "dependencies": {
-            "bufio": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-              "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
-            },
-            "loady": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
-              "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
-            },
-            "nan": {
-              "version": "2.14.2",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-              "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-            }
           }
         },
         "bsert": {
@@ -3542,8 +3525,9 @@
       }
     },
     "fcoin": {
-      "version": "git+https://github.com/mediciland/fcoin.git#31765b1dff1debaf82ea239c8018e10bd055317e",
-      "from": "git+https://github.com/mediciland/fcoin.git#fix-bfilter-bug",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fcoin/-/fcoin-1.1.5.tgz",
+      "integrity": "sha512-3ne3XuApby7fDChTzsk/IGF6Nygf9OztK7A47OWS0I5j+FWo8LMq7dEMIDHMT406z/byv4xe5FjqEL1JHVmFHw==",
       "requires": {
         "@oipwg/fclient": "~0.1.7",
         "bcfg": "~0.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.4",
+  "version": "2.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.2",
+  "version": "2.4.6-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1138,25 +1138,6 @@
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
     },
-    "abstract-leveldown": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-      "optional": true,
-      "requires": {
-        "xtend": "~4.0.0"
-      }
-    },
-    "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-      "optional": true,
-      "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
-      }
-    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -1225,7 +1206,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1255,22 +1237,6 @@
             "remove-trailing-separator": "^1.0.1"
           }
         }
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "optional": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "optional": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -1610,20 +1576,12 @@
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
     },
-    "base64id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
-      "optional": true
-    },
-    "bcoin-native": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/bcoin-native/-/bcoin-native-0.0.23.tgz",
-      "integrity": "sha512-bk2XK9EtOcTiqS4cgJ5dy77R2bVJC65dTvLuhH+SxLemjERC3jbf8jadYvOYfZx/x8TF6fuxZzWruhc0OF3Bnw==",
-      "optional": true,
+    "bcfg": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz",
+      "integrity": "sha512-BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==",
       "requires": {
-        "bindings": "^1.2.1",
-        "nan": "^2.6.2"
+        "bsert": "~0.0.10"
       }
     },
     "bcrypt-pbkdf": {
@@ -1643,6 +1601,51 @@
         }
       }
     },
+    "bcrypto": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.1.11.tgz",
+      "integrity": "sha512-XHsle+v0aYjCyHZSwd3Insnu8GUe4cuf3+f07Z/mO+GLq60YqUyEIvpaSv4LAAJ4uf8UNYMSSQ0LslsV0r4tug==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bufio": "~1.0.6",
+        "loady": "~0.0.1",
+        "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+        }
+      }
+    },
+    "bcurl": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.9.tgz",
+      "integrity": "sha512-WV9LKCqFPtmGwIOqHexJx3Mm/9H/G5bwSCZxJXq9WRrnVQmd58L+Ltxgp/2QicveDG6AgTfepP6JtNiYWbbeHQ==",
+      "requires": {
+        "brq": "~0.1.8",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.9"
+      }
+    },
+    "bdb": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.1.7.tgz",
+      "integrity": "sha512-jtBnWEyDDK08dBbKL9LJeO2huZyBmbjBQMMVjU9RI1liJo6YDbv86uDHoaD4gniefd9pfxqOM1w6rYuwLVCXlQ==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1"
+      }
+    },
+    "bdns": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz",
+      "integrity": "sha512-LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
     "bech32": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
@@ -1654,6 +1657,82 @@
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "requires": {
         "callsite": "1.0.0"
+      }
+    },
+    "bevent": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
+      "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bfile": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz",
+      "integrity": "sha512-X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg=="
+    },
+    "bfilter": {
+      "version": "git+https://github.com/bcoin-org/bfilter.git#252b496e0057e1b59288efe8472fd021c74f5b91",
+      "from": "git+https://github.com/bcoin-org/bfilter.git#semver:~2.0.0",
+      "requires": {
+        "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.3",
+        "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
+        "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
+        "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1",
+        "nan": "git+https://github.com/braydonf/nan.git#semver:~2.14.0"
+      },
+      "dependencies": {
+        "bcrypto": {
+          "version": "git+https://github.com/bcoin-org/bcrypto.git#0a01f693443d8b19f6db1154e0133c7bf703b205",
+          "from": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.3",
+          "requires": {
+            "bufio": "~1.0.6",
+            "loady": "~0.0.1",
+            "nan": "^2.14.0"
+          },
+          "dependencies": {
+            "bufio": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+              "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+            },
+            "loady": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+              "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
+            },
+            "nan": {
+              "version": "2.14.2",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+              "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+            }
+          }
+        },
+        "bsert": {
+          "version": "git+https://github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc",
+          "from": "git+https://github.com/chjj/bsert.git#semver:~0.0.10"
+        },
+        "bufio": {
+          "version": "git+https://github.com/bcoin-org/bufio.git#91ae6c93899ff9fad7d7cee9afd2a1c4933ca984",
+          "from": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6"
+        },
+        "loady": {
+          "version": "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5",
+          "from": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
+        },
+        "nan": {
+          "version": "git+https://github.com/braydonf/nan.git#1dcc61bd06d84e389bfd5311b2b1492a14c74201",
+          "from": "git+https://github.com/braydonf/nan.git#semver:~2.14.0"
+        }
+      }
+    },
+    "bheep": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
+      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
+      "requires": {
+        "bsert": "~0.0.10"
       }
     },
     "big.js": {
@@ -1679,6 +1758,15 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "binet": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.6.tgz",
+      "integrity": "sha512-6pm+Gc3uNiiJZEv0k8JDWqQlo9ki/o9UNAkLmr0EGm7hI5MboOJVIOlO1nw3YuDkLHWN78OPsaC4JhRkn2jMLw==",
+      "requires": {
+        "bs32": "~0.1.5",
+        "bsert": "~0.0.10"
       }
     },
     "bip66": {
@@ -1771,11 +1859,35 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
+    "blru": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz",
+      "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "blst": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz",
+      "integrity": "sha512-TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
     "bluebird": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
       "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
       "dev": true
+    },
+    "bmutex": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz",
+      "integrity": "sha512-nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1884,6 +1996,22 @@
         "node-releases": "^1.1.8"
       }
     },
+    "brq": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
+      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bs32": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
+      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -1916,6 +2044,62 @@
       "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
       "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
     },
+    "bsip": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.9.tgz",
+      "integrity": "sha512-i7cVEfCthASPB3BYKS/pZN/D4kh4vToIlSAFcVBLNjzYl1UirT3E2PIGSfNnYR2qZ3UW1qnDavrWEHhLeSKt2A==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1",
+        "nan": "^2.13.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+        }
+      }
+    },
+    "bsock": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
+      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsocks": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.5.tgz",
+      "integrity": "sha512-w1yG8JmfKPIaTDLuR9TIxJM2Ma6nAiInRpLNZ43g3qPnPHjawCC4SV6Bdy84bEJQX1zJWYTgdod/BnQlDhq4Gg==",
+      "requires": {
+        "binet": "~0.3.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bstring": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.9.tgz",
+      "integrity": "sha512-D95flI7SXL+UsQi9mW+hH+AK2AFfafIJi+3GbbyTAWMe2FqwR9keBxsjGiGd/JM+77Y9WsC+M4EhZVNVcym9jw==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1",
+        "nan": "^2.13.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+        }
+      }
+    },
+    "btcp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
+      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A=="
+    },
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -1945,15 +2129,52 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
+    "buffer-map": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz",
+      "integrity": "sha512-95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ=="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "bupnp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz",
+      "integrity": "sha512-J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==",
+      "requires": {
+        "binet": "~0.3.5",
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bval": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
+      "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bweb": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz",
+      "integrity": "sha512-3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -2074,12 +2295,6 @@
         "upath": "^1.1.0"
       }
     },
-    "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-      "optional": true
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -2182,7 +2397,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "coinselect": {
       "version": "3.1.11",
@@ -2254,11 +2470,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -2273,12 +2484,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "optional": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -2410,21 +2615,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "optional": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "optional": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2517,22 +2707,10 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "optional": true
-    },
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
       "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2623,74 +2801,6 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "engine.io": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
-      "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
-      "optional": true,
-      "requires": {
-        "accepts": "~1.3.4",
-        "base64id": "1.0.0",
-        "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "uws": "~9.14.0",
-        "ws": "~3.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "optional": true
-        }
-      }
-    },
-    "engine.io-client": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
-      "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
-      "optional": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "optional": true
-        }
       }
     },
     "engine.io-parser": {
@@ -3281,12 +3391,6 @@
         }
       }
     },
-    "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
-      "optional": true
-    },
     "expect": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
@@ -3416,12 +3520,6 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
-    "fast-future": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo=",
-      "optional": true
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3444,49 +3542,45 @@
       }
     },
     "fcoin": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/fcoin/-/fcoin-1.0.0-beta.34.tgz",
-      "integrity": "sha512-ps2IhgAVmi9nyDBGuhfnUunLevqKE0skVtcepHVGDuE+fPzexwD14NFJrxhKVk3scwjGfarNwhWnL99o8m1vHA==",
+      "version": "git+https://github.com/mediciland/fcoin.git#31765b1dff1debaf82ea239c8018e10bd055317e",
+      "from": "git+https://github.com/mediciland/fcoin.git#fix-bfilter-bug",
       "requires": {
-        "bcoin-native": "0.0.23",
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0",
-        "leveldown": "1.7.2",
-        "n64": "0.0.18",
-        "secp256k1": "3.3.0",
-        "socket.io": "2.0.3",
-        "socket.io-client": "2.0.3"
+        "@oipwg/fclient": "~0.1.7",
+        "bcfg": "~0.1.6",
+        "bcrypto": "~3.1.11",
+        "bdb": "~1.1.7",
+        "bdns": "~0.1.5",
+        "bevent": "~0.1.5",
+        "bfile": "~0.2.1",
+        "bfilter": "git+https://github.com/bcoin-org/bfilter.git#semver:~2.0.0",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.5",
+        "blgr": "~0.1.7",
+        "blru": "~0.1.6",
+        "blst": "~0.1.5",
+        "bmutex": "~0.1.6",
+        "bsert": "~0.0.10",
+        "bsip": "~0.1.9",
+        "bsock": "~0.1.9",
+        "bsocks": "~0.2.5",
+        "bstring": "~0.3.9",
+        "btcp": "~0.1.5",
+        "buffer-map": "~0.0.7",
+        "bufio": "~1.0.6",
+        "bupnp": "~0.2.6",
+        "bval": "~0.1.6",
+        "bweb": "~0.1.9",
+        "n64": "~0.2.10"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-          "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+        "@oipwg/fclient": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/@oipwg/fclient/-/fclient-0.1.7.tgz",
+          "integrity": "sha512-mrLXFj1sz3CxpLib/mp9vntQnkofUBwECCiSWyb0BKAwM1g68w3fsp0IkF3G7gmcs5XcTVyuuor91O39qTk7Wg==",
           "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
-        "secp256k1": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.0.tgz",
-          "integrity": "sha512-CbrQoeGG5V0kQ1ohEMGI+J7oKerapLTpivLICBaXR0R4HyQcN3kM9itLsV5fdpV1UR1bD14tOkJ1xughmlDIiQ==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.2.1",
-            "bip66": "^1.1.3",
-            "bn.js": "^4.11.3",
-            "create-hash": "^1.1.2",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.2.3",
-            "nan": "^2.2.1",
-            "prebuild-install": "^2.0.0",
-            "safe-buffer": "^5.1.0"
+            "bcfg": "~0.1.6",
+            "bcurl": "~0.1.6",
+            "bsert": "~0.0.10"
           }
         }
       }
@@ -3685,7 +3779,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3709,13 +3804,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3732,19 +3829,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3875,7 +3975,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3889,6 +3990,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3905,6 +4007,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3913,13 +4016,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3940,6 +4045,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4028,7 +4134,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4042,6 +4149,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4137,7 +4245,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4179,6 +4288,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4200,6 +4310,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4248,13 +4359,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4269,22 +4382,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "optional": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -4327,12 +4424,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "optional": true
     },
     "glob": {
       "version": "7.1.3",
@@ -4488,12 +4579,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "optional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -4660,12 +4745,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "optional": true
     },
     "inquirer": {
       "version": "5.2.0",
@@ -5228,15 +5307,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "dev": true,
+      "optional": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -6550,33 +6622,6 @@
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
       "dev": true
     },
-    "leveldown": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-      "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-      "optional": true,
-      "requires": {
-        "abstract-leveldown": "~2.6.1",
-        "bindings": "~1.2.1",
-        "fast-future": "~1.0.2",
-        "nan": "~2.6.1",
-        "prebuild-install": "^2.1.0"
-      },
-      "dependencies": {
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-          "optional": true
-        },
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-          "optional": true
-        }
-      }
-    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -6613,6 +6658,11 @@
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
       }
+    },
+    "loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
     },
     "locate-path": {
       "version": "3.0.0",
@@ -6811,12 +6861,14 @@
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.38.0"
       }
@@ -6826,12 +6878,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
-    },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "optional": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -6881,6 +6927,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -6888,7 +6935,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -6938,9 +6986,9 @@
       "dev": true
     },
     "n64": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/n64/-/n64-0.0.18.tgz",
-      "integrity": "sha512-z5gRoCNFTY5fderO8n5tt6p7+jZiivzN1LhuR4EqrTkciYDCpJy8xkwkd1YO5eyfimeLAjXy/6k3FLC+GQ6lLw=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz",
+      "integrity": "sha512-uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ=="
     },
     "nan": {
       "version": "2.12.1",
@@ -6983,12 +7031,6 @@
         "through2": "^2.0.3"
       }
     },
-    "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "optional": true
-    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
@@ -7000,15 +7042,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-abi": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
-      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
-      "optional": true,
-      "requires": {
-        "semver": "^5.4.1"
-      }
     },
     "node-forge": {
       "version": "0.7.6",
@@ -7078,12 +7111,6 @@
         "promise": "~1.3.0"
       }
     },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "optional": true
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -7112,22 +7139,11 @@
         "path-key": "^2.0.0"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "optional": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.1.4",
@@ -7144,7 +7160,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-component": {
       "version": "0.0.3",
@@ -7256,12 +7273,6 @@
           "dev": true
         }
       }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "optional": true
     },
     "os-locale": {
       "version": "3.1.0",
@@ -7653,29 +7664,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7800,16 +7788,6 @@
       "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
       "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
     },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "optional": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -7835,18 +7813,6 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "optional": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
       }
     },
     "react-is": {
@@ -8321,12 +8287,14 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -8384,7 +8352,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "signed-varint": {
       "version": "2.0.1",
@@ -8392,23 +8361,6 @@
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "requires": {
         "varint": "~5.0.0"
-      }
-    },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-      "optional": true
-    },
-    "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-      "optional": true,
-      "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
       }
     },
     "sisteransi": {
@@ -8564,112 +8516,6 @@
           "requires": {
             "is-buffer": "^1.1.5"
           }
-        }
-      }
-    },
-    "socket.io": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.3.tgz",
-      "integrity": "sha1-Q1nwaiSTOua9CHeYr3jGgOrjReM=",
-      "optional": true,
-      "requires": {
-        "debug": "~2.6.6",
-        "engine.io": "~3.1.0",
-        "object-assign": "~4.1.1",
-        "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "~2.0.2",
-        "socket.io-parser": "~3.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "optional": true
-        }
-      }
-    },
-    "socket.io-adapter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
-      "optional": true
-    },
-    "socket.io-client": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.3.tgz",
-      "integrity": "sha1-bK9K/5+FsZ/ZG2zhPWmttWT4hzs=",
-      "optional": true,
-      "requires": {
-        "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "optional": true
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
-      "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "has-binary2": "~1.0.2",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -8927,16 +8773,6 @@
         }
       }
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8949,6 +8785,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -8968,7 +8805,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
@@ -9043,30 +8881,6 @@
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
-    },
-    "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-      "optional": true,
-      "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "optional": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
     },
     "tar-stream": {
       "version": "1.6.2",
@@ -9240,6 +9054,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -9300,11 +9115,6 @@
           "optional": true
         }
       }
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "underscore": {
       "version": "1.9.1",
@@ -9461,12 +9271,6 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
-    "uws": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
-      "integrity": "sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg==",
-      "optional": true
-    },
     "v8flags": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
@@ -9575,21 +9379,6 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "optional": true
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "optional": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "wif": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
@@ -9615,16 +9404,6 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
-      }
-    },
-    "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-      "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
       }
     },
     "xml-name-validator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.0",
+  "version": "2.4.6-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1758,6 +1758,14 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
       "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
+    "blgr": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.8.tgz",
+      "integrity": "sha512-9AvDK+lc92q//63S8cHtkaB060YOZqoqd0DkMwn35mR1SrcY0FXnCHePHZFx6Oe1d/6wj8Lw7mKEGoShCUf3Yw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -1902,6 +1910,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
     },
     "buffer-alloc": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.12",
+  "version": "2.4.6-beta.13",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.2",
+  "version": "2.4.6-beta.3",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.24",
+  "version": "2.4.6-beta.25",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.25",
+  "version": "2.4.6-beta.26",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "js-oip",
-  "version": "2.4.5",
+  "version": "2.4.6-beta.1",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {
-    "test": "npm run test:unit && npm run test:format",
+    "test": "npm run test:unit",
     "test:flo": "jest test/unit/modules/flo",
     "test:unit": "jest test/unit --detectOpenHandles --verbose",
     "test:integration": "jest test/integration --detectOpenHandles --verbose",
@@ -13,8 +13,7 @@
     "prepublishOnly": "npm run test && npm run compile",
     "code-format": "standard --fix",
     "prepush": "npm run compile && npm run generate-docs",
-    "generate-docs": "node_modules/.bin/jsdoc --readme ./README.md -c jsdoc.json",
-    "postinstall": "npm run compile"
+    "generate-docs": "node_modules/.bin/jsdoc --readme ./README.md -c jsdoc.json"
   },
   "repository": {
     "type": "git",
@@ -63,8 +62,7 @@
     "wif": "^2.0.6"
   },
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.20",
+  "version": "2.4.6-beta.21",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.1",
+  "version": "2.4.6-beta.2",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.17",
+  "version": "2.4.6-beta.18",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.18",
+  "version": "2.4.6-beta.19",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.3",
+  "version": "2.4.6-beta.5",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {
@@ -50,11 +50,11 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "bitcoinjs-lib": "^5.0.3",
-    "bitcoinjs-message": "^2.0.0",
+    "bitcoinjs-lib": "5.0.3",
+    "bitcoinjs-message": "2.0.0",
     "blgr": "^0.1.8",
     "coinselect": "^3.1.11",
-    "fcoin": "^1.0.0-beta.34",
+    "fcoin": "git+https://github.com/mediciland/fcoin.git#fix-bfilter-bug",
     "insight-explorer": "^1.0.10",
     "ipfs-http-client": "^28.0.0",
     "node-localstorage": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.5",
+  "version": "2.4.6-beta.6",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.8-beta.2",
+  "version": "2.4.9",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.14",
+  "version": "2.4.6-beta.15",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.27",
+  "version": "2.4.6-beta.29",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.16",
+  "version": "2.4.6-beta.17",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.9",
+  "version": "2.4.6-beta.10",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.11",
+  "version": "2.4.6-beta.12",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.8",
+  "version": "2.4.6-beta.9",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.26",
+  "version": "2.4.6-beta.27",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.7",
+  "version": "2.4.8-beta.1",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.13",
+  "version": "2.4.6-beta.14",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.22",
+  "version": "2.4.6-beta.23",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.23",
+  "version": "2.4.6-beta.24",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.15",
+  "version": "2.4.6-beta.16",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.10",
+  "version": "2.4.6-beta.11",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.29",
+  "version": "2.4.7",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.19",
+  "version": "2.4.6-beta.20",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "axios": "^0.19.0",
     "bitcoinjs-lib": "^5.0.3",
     "bitcoinjs-message": "^2.0.0",
+    "blgr": "^0.1.8",
     "coinselect": "^3.1.11",
     "fcoin": "^1.0.0-beta.34",
     "insight-explorer": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.8-beta.1",
+  "version": "2.4.8-beta.2",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.6",
+  "version": "2.4.6-beta.7",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepublishOnly": "npm run test && npm run compile",
     "code-format": "standard --fix",
     "prepush": "npm run compile && npm run generate-docs",
-    "generate-docs": "node_modules/.bin/jsdoc --readme ./README.md -c jsdoc.json"
+    "generate-docs": "node_modules/.bin/jsdoc --readme ./README.md -c jsdoc.json",
+    "postinstall": "npm run compile"
   },
   "repository": {
     "type": "git",
@@ -62,7 +63,8 @@
     "wif": "^2.0.6"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bitcoinjs-message": "2.0.0",
     "blgr": "^0.1.8",
     "coinselect": "^3.1.11",
-    "fcoin": "git+https://github.com/mediciland/fcoin.git#fix-bfilter-bug",
+    "fcoin": "1.1.5",
     "insight-explorer": "^1.0.10",
     "ipfs-http-client": "^28.0.0",
     "node-localstorage": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.21",
+  "version": "2.4.6-beta.22",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-oip",
-  "version": "2.4.6-beta.7",
+  "version": "2.4.6-beta.8",
   "description": "A Javascript Library to fully interact with the Open Index Protocol",
   "main": "lib/index.js",
   "scripts": {

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -51,7 +51,10 @@ class Peer {
     this.peer.parser.on('packet', this.onPacket.bind(this))
     // Handle/log errors
     this.peer.parser.on('error', (e) => {
-      console.log('Peer Error: ' + e)
+      console.error(e)
+    })
+    this.peer.on('error', (e) => {
+      console.error(e)
     })
 
     try {

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -78,7 +78,7 @@ class Peer {
     if (this.connected) {
       try {
         // Create an `fcoin` transaction from our tx hex
-        let mytx = TX().fromRaw(Buffer.from(hex, 'hex'))
+        let mytx = new TX().fromRaw(Buffer.from(hex, 'hex'))
 
         // Store the hash of the transaction in our txMap
         this.txMap[mytx.hash('hex')] = hex
@@ -131,7 +131,7 @@ class Peer {
         if (!this.txMap[item.hash]) { return }
 
         // Create an `fcoin` tx from the cached tx hex
-        let mytx = TX().fromRaw(Buffer.from(this.txMap[item.hash], 'hex'))
+        let mytx = new TX().fromRaw(Buffer.from(this.txMap[item.hash], 'hex'))
         // Include the transaction in a TXPacket to be sent to the Peer
         let txPacket = packets.TXPacket(mytx, segTX)
 

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -46,9 +46,9 @@ class Peer {
     this.peer.connect(address)
 
     // When we recieve packets from peers, process them using the onPacket function
-    this.peer.on('packet', this.onPacket.bind(this))
+    this.peer.parser.on('packet', this.onPacket.bind(this))
     // Handle/log errors
-    this.peer.on('error', (e) => {
+    this.peer.parser.on('error', (e) => {
       console.log('Peer Error: ' + e)
     })
 

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -30,7 +30,7 @@ class Peer {
    * @return {Boolean} Returns the connection status
    */
   async connect () {
-    let log = Logger({ level: 'spam' })
+    let log = new Logger({ level: 'spam' })
     // Create the Fcoin Peer
     this.peer = peer.fromOptions({
       logger: log,

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -36,10 +36,7 @@ class Peer {
     this.peer = fPeer.fromOptions({
       logger: log,
       network: this.settings.network,
-      agent: this.settings.agent,
-      hasWitness: () => {
-        return false
-      }
+      agent: this.settings.agent
     })
 
     // Create a NetAddress from our passed in IP address:port

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -147,7 +147,7 @@ class Peer {
         // Create an `fcoin` tx from the cached tx hex
         let mytx = new TX().fromRaw(Buffer.from(this.txMap[item.hash.toString('hex')], 'hex'))
         // Include the transaction in a TXPacket to be sent to the Peer
-        let txPacket = packets.TXPacket(mytx, segTX)
+        let txPacket = new packets.TXPacket(mytx, segTX)
 
         // Send out the TXPacket to the Peer
         this.peer.send(txPacket)

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -1,4 +1,5 @@
 import { peer, netaddress, packets, tx, logger, invitem } from 'fcoin'
+import Logger from 'blgr'
 
 /* Create a Flo p2p Peer */
 class Peer {
@@ -29,7 +30,7 @@ class Peer {
    * @return {Boolean} Returns the connection status
    */
   async connect () {
-    let log = logger({ level: 'spam' })
+    let log = Logger({ level: 'spam' })
     // Create the Fcoin Peer
     this.peer = peer.fromOptions({
       logger: log,

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -129,13 +129,8 @@ class Peer {
     // If the peer is requesting more than one transaction, or if they have not met the singlelog maximum, then log the request
     if (getDataPacket.items.length > 1 || this.singleLog < 5) { console.log(`[RPC Wallet] Peer ${this.settings.ip} requested ${getDataPacket.items.length} items...`) }
 
-    let loggedYet = false
     // Loop through each requested item in the getData packet
     for (let item of getDataPacket.items) {
-      if (!loggedYet) {
-        console.log(item)
-        loggedYet = true
-      }
       // We only care about responding if they are requesting a transction
       let regTX = (item.type === InvItem.types.TX)
       let segTX = (item.type === InvItem.types.WITNESS_TX)

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -1,6 +1,6 @@
 import { Peer as fPeer, TX, InvItem, net } from 'fcoin'
 const { NetAddress, packets } = net
-import blgr from 'blgr'
+import Logger from 'blgr'
 
 /* Create a Flo p2p Peer */
 class Peer {
@@ -31,7 +31,7 @@ class Peer {
    * @return {Boolean} Returns the connection status
    */
   async connect () {
-    let log = blgr.logger('spam');
+    let log = new Logger({ level: 'spam' })
     // Create the Fcoin Peer
     this.peer = fPeer.fromOptions({
       logger: log,

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -1,6 +1,6 @@
 import { Peer as fPeer, TX, InvItem, net } from 'fcoin'
 const { NetAddress, packets } = net
-import Logger from 'blgr'
+import blgr from 'blgr'
 
 /* Create a Flo p2p Peer */
 class Peer {
@@ -31,7 +31,7 @@ class Peer {
    * @return {Boolean} Returns the connection status
    */
   async connect () {
-    let log = new Logger({ level: 'spam' })
+    let log = blgr.logger('spam');
     // Create the Fcoin Peer
     this.peer = fPeer.fromOptions({
       logger: log,

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -139,13 +139,13 @@ class Peer {
       // If we are a regular tx, or a segwit tx, then continue
       if (regTX || segTX) {
         // Check to see if we have this transction in our txMap, and if not, skip it (ignore transactions that are not our own)
-        if (!this.txMap[item.hash.toString('X')]) { 
+        if (!this.txMap[item.hash.toString('hex')]) { 
           console.error(`Item Peer requested is NOT in our txMap`)
           continue 
         }
 
         // Create an `fcoin` tx from the cached tx hex
-        let mytx = new TX().fromRaw(Buffer.from(this.txMap[item.hash.toString('X')], 'hex'))
+        let mytx = new TX().fromRaw(Buffer.from(this.txMap[item.hash.toString('hex')], 'hex'))
         // Include the transaction in a TXPacket to be sent to the Peer
         let txPacket = packets.TXPacket(mytx, segTX)
 

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -68,23 +68,30 @@ class Peer {
 
   /**
    * Announce the availability of a Transaction to the Peer
-   * @param  {String} hex - The hex string of the transaction
+   * @param  {Array.<String>} hex - The hex string of the transaction
    */
-  announceTX (hex) {
+  announceTXs (hexArray) {
     // First, check if we are connected before attempting to broadcast out
     if (this.connected) {
       try {
-        // Create an `fcoin` transaction from our tx hex
-        let mytx = new TX().fromRaw(Buffer.from(hex, 'hex'))
+        let txArray = []
+        for (let hex of hexArray) {
+          // Create an `fcoin` transaction from our tx hex
+          let mytx = new TX().fromRaw(Buffer.from(hex, 'hex'))
 
-        // Store the hash of the transaction in our txMap
-        this.txMap[mytx.hash('hex')] = hex
+          // Store the hash of the transaction in our txMap
+          this.txMap[mytx.hash('hex')] = hex
 
-        // Announce the Transaction to the peer
-        this.peer.announceTX(mytx)
+          // Add it to our array to announce
+          txArray.push(mytx)
+        }
+
+        // Announce the Transactions to the peer
+        this.peer.announceTX(txArray)
+        this.peer.flushInv()
       } catch (e) {
         // Throw an error if one happened
-        console.error('Announce TX Error: ' + e)
+        console.error('Announce TXs Error: ' + e)
       }
     }
   }

--- a/src/modules/flo/Peer.js
+++ b/src/modules/flo/Peer.js
@@ -139,13 +139,13 @@ class Peer {
       // If we are a regular tx, or a segwit tx, then continue
       if (regTX || segTX) {
         // Check to see if we have this transction in our txMap, and if not, skip it (ignore transactions that are not our own)
-        if (!this.txMap[item.hash]) { 
+        if (!this.txMap[item.hash.toString('X')]) { 
           console.error(`Item Peer requested is NOT in our txMap`)
           continue 
         }
 
         // Create an `fcoin` tx from the cached tx hex
-        let mytx = new TX().fromRaw(Buffer.from(this.txMap[item.hash], 'hex'))
+        let mytx = new TX().fromRaw(Buffer.from(this.txMap[item.hash.toString('X')], 'hex'))
         // Include the transaction in a TXPacket to be sent to the Peer
         let txPacket = packets.TXPacket(mytx, segTX)
 

--- a/src/modules/multipart/multipartx.js
+++ b/src/modules/multipart/multipartx.js
@@ -36,11 +36,8 @@ class MultipartX {
     while (jsonString.length > maximumLength) {
       // If we have between 100 and 999 parts, our max length needs to be reduced by one
       if (chunks.length >= 99) { maximumLength = CHOP_MAX_LEN - 1 }
-      // If we have between 1000 and 9999 parts, our max length needs to be reduced by one
-      if (chunks.length >= 999) { maximumLength = CHOP_MAX_LEN - 2 }
-      // If we have between 10000 and 99999 parts, our max length needs to be reduced by one
-      if (chunks.length >= 9999) { maximumLength = CHOP_MAX_LEN - 3 }
-      // If we have a 100,000 part multipart transaction, we really need to be rethinking our plan...
+      // If we have a 1,000 part multipart transaction, we really need to be rethinking our plan and instead store
+      // data inside IPFS or something else...
       
       chunks.push(jsonString.slice(0, maximumLength))
       jsonString = jsonString.slice(maximumLength)

--- a/src/modules/multipart/multipartx.js
+++ b/src/modules/multipart/multipartx.js
@@ -34,8 +34,8 @@ class MultipartX {
     // ToDo:: FLODATA_MAX_LEN vs CHOP_MAX_LEN
     let maximumLength = CHOP_MAX_LEN
     while (jsonString.length > maximumLength) {
-      // If we have between 100 and 999 parts, our max length needs to be reduced by one
-      if (chunks.length >= 99) { maximumLength = CHOP_MAX_LEN - 1 }
+      // If we have between 100 and 999 parts, our max length needs to be reduced by two
+      if (chunks.length >= 99) { maximumLength = CHOP_MAX_LEN - 2 }
       // If we have a 1,000 part multipart transaction, we really need to be rethinking our plan and instead store
       // data inside IPFS or something else...
       

--- a/src/modules/multipart/multipartx.js
+++ b/src/modules/multipart/multipartx.js
@@ -32,9 +32,18 @@ class MultipartX {
   fromString (jsonString) {
     let chunks = []
     // ToDo:: FLODATA_MAX_LEN vs CHOP_MAX_LEN
-    while (jsonString.length > CHOP_MAX_LEN) {
-      chunks.push(jsonString.slice(0, CHOP_MAX_LEN))
-      jsonString = jsonString.slice(CHOP_MAX_LEN)
+    let maximumLength = CHOP_MAX_LEN
+    while (jsonString.length > maximumLength) {
+      // If we have between 100 and 999 parts, our max length needs to be reduced by one
+      if (chunks.length >= 99) { maximumLength = CHOP_MAX_LEN - 1 }
+      // If we have between 1000 and 9999 parts, our max length needs to be reduced by one
+      if (chunks.length >= 999) { maximumLength = CHOP_MAX_LEN - 2 }
+      // If we have between 10000 and 99999 parts, our max length needs to be reduced by one
+      if (chunks.length >= 9999) { maximumLength = CHOP_MAX_LEN - 3 }
+      // If we have a 100,000 part multipart transaction, we really need to be rethinking our plan...
+      
+      chunks.push(jsonString.slice(0, maximumLength))
+      jsonString = jsonString.slice(maximumLength)
     }
     chunks.push(jsonString)
 

--- a/src/modules/multipart/multipartx.js
+++ b/src/modules/multipart/multipartx.js
@@ -31,14 +31,16 @@ class MultipartX {
    */
   fromString (jsonString) {
     let chunks = []
+
     // ToDo:: FLODATA_MAX_LEN vs CHOP_MAX_LEN
     let maximumLength = CHOP_MAX_LEN
+
+    // If we have between 100 and 999 parts, our max length needs to be reduced by a few
+    if (jsonString.length / maximumLength >= 99) { maximumLength = CHOP_MAX_LEN - 4 }
+    // If we have a 1,000 part multipart transaction, we really need to be rethinking our plan and instead store
+    // data inside IPFS or something else...
+
     while (jsonString.length > maximumLength) {
-      // If we have between 100 and 999 parts, our max length needs to be reduced by two
-      if (chunks.length >= 99) { maximumLength = CHOP_MAX_LEN - 2 }
-      // If we have a 1,000 part multipart transaction, we really need to be rethinking our plan and instead store
-      // data inside IPFS or something else...
-      
       chunks.push(jsonString.slice(0, maximumLength))
       jsonString = jsonString.slice(maximumLength)
     }

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -349,6 +349,9 @@ class RPCWallet {
     // Increase the ancestor size (byte length)
     this.currentAncestorSize += hex.length
 
+    // Every 100 update our count
+    if (this.currentAncestorCount % 100 === 0) { await this.updateAncestorStatus() }
+
     // Log every 25
     if (this.currentAncestorCount % 25 === 0) { console.log(`[RPC Wallet] Updated Ancestor Count: ${this.currentAncestorCount} - Updated Ancestor Size: ${(this.currentAncestorSize / ONE_MB).toFixed(2)}MB`) }
 

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -219,7 +219,7 @@ class RPCWallet {
     let foundUnconfirmed = false
 
     let numberConfirmed = 0
-    while (!foundUnconfirmed || this.unconfirmedTxids.length === 0) {
+    while (this.unconfirmedTxids.length !== 0 && !foundUnconfirmed) {
       let txidToCheck = this.unconfirmedTxids[0]
 
       // Check to see if the utxo is still in the mempool and if it has ancestors

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -27,11 +27,11 @@ const MAX_MEMPOOL_ANCESTORS = 1250
 const MAX_MEMPOOL_ANCESTOR_SIZE = 1.75 * ONE_MB
 
 // Timer lengths used to track and fix the Ancestor chain
-const UPDATE_ANCESTOR_STATUS = 1 * ONE_SECOND
+const UPDATE_ANCESTOR_STATUS = 5 * ONE_SECOND
 const REPAIR_ANCESTORS_AFTER = 1 * ONE_MINUTE
-const PEER_CONNECT_LENGTH = 2 * ONE_SECOND
-const REBROADCAST_LENGTH = 10 * ONE_SECOND
-const CONFIRMATION_CHECK_LENGTH = 2 * ONE_SECOND
+const PEER_CONNECT_LENGTH = 5 * ONE_SECOND
+const REBROADCAST_LENGTH = 30 * ONE_SECOND
+const CONFIRMATION_CHECK_LENGTH = 20 * ONE_SECOND
 const CONFIRMATION_REBROADCAST_DELAY = 1 * ONE_MINUTE
 const REPAIR_MIN_TX = 100
 
@@ -163,6 +163,7 @@ class RPCWallet {
     // Repair mode tracker
     this.repairMode = false
     this.rebroadcasting = false
+    this.checkingAncestorCount = false
   }
 
   /**
@@ -342,6 +343,8 @@ class RPCWallet {
    * @return {Boolean} Returns `true` once it is safe to continue sending transactions
    */
   async checkAncestorCount (forceUpdateAncestor) {
+    if (this.checkingAncestorCount) { return }
+    this.checkingAncestorCount = true
     // Store our starting count
     let startAncestorCount = this.currentAncestorCount
     let startAncestorSize = this.currentAncestorSize
@@ -411,6 +414,7 @@ class RPCWallet {
 
     // If we enabled repair mode, then
     this.repairMode = false
+    this.checkingAncestorCount = false
 
     // There are fewer ancestors than the maximum, so we can send the next transaction!
     return true

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -247,6 +247,7 @@ class RPCWallet {
       } else {
         // Break out of the while loop once there is a transaciton that exists in the Mempool
         foundUnconfirmed = true
+        console.log(`Oldest TX in mempool ${txidToCheck}`)
       }
     }
   }

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -162,6 +162,7 @@ class RPCWallet {
 
     // Repair mode tracker
     this.repairMode = false
+    this.rebroadcasting = false
   }
 
   /**
@@ -419,6 +420,12 @@ class RPCWallet {
    * Rebroadcast out all transactions on our local mempool
    */
   async rebroadcastTransactions () {
+    // Lock rebroadcasting; Only perform a single rebroadcast at a time!!
+    if (this.rebroadcasting) { 
+      console.log(`[RPC Wallet] Already rebroadcasting transactions...`)
+      return 
+    }
+    this.rebroadcasting = true
     // Announce that we are starting
     console.log(`[RPC Wallet] Announcing ${this.unconfirmedTransactions.length} transactions to Peers...`)
 
@@ -444,6 +451,8 @@ class RPCWallet {
 
     // Destroy the peers we connected too
     this.destroyPeers()
+    // Unlock rebroadcasting
+    this.rebroadcasting = false
   }
 
   /**

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -242,7 +242,7 @@ class RPCWallet {
           this.currentAncestorSize = 0
         } else {
           // If we have gotten here, that means the transaction has zero confirmations, and is not included in the mempool, and so we need to repair it's chain...
-          console.log('[RPC Wallet] [WARNING] The most recent unspent transaction has zero confirmations and is not in the mempool! Attempting to repair mempool by rebroadcasting transactions, please wait... (txid: ' + mostRecentTXID + ')')
+          console.log(`[RPC Wallet] [WARNING] The most recent unspent transaction has zero confirmations and is not in the mempool! Attempting to repair mempool by rebroadcasting transactions, please wait... (txid: ${mostRecentTXID}) ${JSON.stringify(checkConfirmations)}`)
           await this.rebroadcastTransactions()
 
           // Don't update anything, and return for now, so that `updateAncestorStatus` will run again
@@ -266,6 +266,8 @@ class RPCWallet {
       this.currentAncestorCount++
     }
 
+    console.log(`[RPC Wallet] Updated Ancestor Count: ${this.currentAncestorCount} - Updated Ancestor Size: ${(this.currentAncestorSize / ONE_MB).toFixed(2)}MB`) 
+
     return true
   }
 
@@ -274,14 +276,16 @@ class RPCWallet {
    * @param {String} hex - The transaction hex to count
    * @return {Boolean} Returns true on success
    */
-  addAncestor (hex) {
+  async addAncestor (hex) {
     // Increase the ancestor count
     this.currentAncestorCount++
     // Increase the ancestor size (byte length)
     this.currentAncestorSize += Buffer.from(hex, 'hex').length
 
-    // Log every 50
-    if (this.currentAncestorCount % 50 === 0) { console.log(`[RPC Wallet] Updated Ancestor Count: ${this.currentAncestorCount} - Updated Ancestor Size: ${(this.currentAncestorSize / ONE_MB).toFixed(2)}MB`) }
+    // Every 25 update the ancestor count
+    if (this.currentAncestorCount % 25 === 0) { 
+      await this.updateAncestorStatus()
+    }
 
     return true
   }

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -28,9 +28,9 @@ const MAX_MEMPOOL_ANCESTOR_SIZE = 1.75 * ONE_MB
 
 // Timer lengths used to track and fix the Ancestor chain
 const UPDATE_ANCESTOR_STATUS = 5 * ONE_SECOND
-const REPAIR_ANCESTORS_AFTER = 1 * ONE_MINUTE
-const PEER_CONNECT_LENGTH = 5 * ONE_SECOND
-const REBROADCAST_LENGTH = 30 * ONE_SECOND
+const REPAIR_ANCESTORS_AFTER = 10 * ONE_SECOND
+const PEER_CONNECT_LENGTH = 2 * ONE_SECOND
+const REBROADCAST_LENGTH = 10 * ONE_SECOND
 const CONFIRMATION_CHECK_INTERVAL = 20 * ONE_SECOND
 const CONFIRMATION_CHECK_UPDATE_ANCESTORS_AFTER = 5 * ONE_MINUTE
 const CONFIRMATION_REBROADCAST_DELAY = 2 * ONE_MINUTE
@@ -838,7 +838,9 @@ class RPCWallet {
       return 
     }
 
-    console.log(`[RPC Wallet] Checking ${this.getConfirmationSubscriptionCount()} transations for confirmations...`)
+    // Note: Occasionally this will log a lower number than the Ancestor Count, this occurs
+    // when a Multipart record is subscribed to using the onConfirmation subscription.
+    console.log(`[RPC Wallet] Checking ${this.getConfirmationSubscriptionCount()} confirmation subscriptions...`)
     for (let subscription in this.onConfirmationSubscriptions) {
       let { txids, record, options } = this.onConfirmationSubscriptions[subscription]
 

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -219,7 +219,7 @@ class RPCWallet {
     let foundUnconfirmed = false
 
     let numberConfirmed = 0
-    while (!foundUnconfirmed) {
+    while (!foundUnconfirmed || this.unconfirmedTxids.length === 0) {
       let txidToCheck = this.unconfirmedTxids[0]
 
       // Check to see if the utxo is still in the mempool and if it has ancestors

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -20,7 +20,7 @@ const TX_AVG_BYTE_SIZE = 200
 const SAT_PER_FLO = 100000000
 
 // The minimum amount a utxo is allowed to be for us to use
-const MIN_UTXO_AMOUNT = 0.0001
+const MIN_UTXO_AMOUNT = 1
 
 // Prevent chaining over ancestor limit
 const MAX_MEMPOOL_ANCESTORS = 1225
@@ -859,7 +859,8 @@ class RPCWallet {
         try {
           await options.onConfirmation(record, txids, options.onConfirmationRef)
         } catch (e) {
-          console.warning(`[RPC Wallet] Error when running onConfirmation function in subscription: `, e)
+          console.error(`[RPC Wallet] Error when running onConfirmation function in subscription: `)
+          console.error(e)
         }
         delete this.onConfirmationSubscriptions[subscription]
       }

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -437,18 +437,10 @@ class RPCWallet {
     await this.connectToPeers()
 
     // Announce all of our local unconfirmed transactions
-    let numAnnounced = 0
-    for (let txHex of this.unconfirmedTransactions) {
-      // Loop through all peers and announce TX individually to each (if we have connected to them\
-      for (let peer of this.peers) {
-        if (peer.connected) { await peer.announceTX(txHex) }
-      }
-
-      // Log every 50 transactions
-      numAnnounced++
-      if (numAnnounced % 50 === 0) { console.log(`[RPC Wallet] Announced ${numAnnounced}/${this.unconfirmedTransactions.length} transactions so far...`) }
+    // Loop through all peers and announce TXs to each (if we have connected to them)
+    for (let peer of this.peers) {
+      await peer.announceTXs(this.unconfirmedTransactions)
     }
-    console.log(`[RPC Wallet] Announced ${numAnnounced} transactions!`)
 
     // Wait for REBROADCAST_LENGTH in order to give some time for transactions to be requested, and sent out.
     await new Promise((resolve, reject) => { setTimeout(() => { resolve() }, REBROADCAST_LENGTH) })

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -28,7 +28,7 @@ const MAX_MEMPOOL_ANCESTOR_SIZE = 1.50 * ONE_MB
 
 // Timer lengths used to track and fix the Ancestor chain
 const UPDATE_ANCESTOR_STATUS = 5 * ONE_SECOND
-const REPAIR_ANCESTORS_AFTER = 40 * ONE_SECOND // One FLO Block on average
+const REPAIR_ANCESTORS_AFTER = 1 * ONE_MINUTE // One FLO Block on average
 const PEER_CONNECT_LENGTH = 2 * ONE_SECOND
 const PEER_DESTROY_LENGTH = 5 * ONE_SECOND
 const REBROADCAST_LENGTH = 10 * ONE_SECOND
@@ -415,16 +415,16 @@ class RPCWallet {
     //   this.unconfirmedTransactions.shift()
     //   this.unconfirmedTxids.shift()
     // }
-    let numberConfirmed = await this.checkAllUnconfirmed()
+    // let numberConfirmed = await this.checkAllUnconfirmed()
 
-    // Check to see how many transactions got confirmed
-    if (startAncestorCount >= MAX_MEMPOOL_ANCESTORS || startAncestorSize >= MAX_MEMPOOL_ANCESTOR_SIZE) {
-      // If there are less confirmed than REPAIR_MIN_TX, then rebroadcast the transactions
-      if (numberConfirmed < REPAIR_MIN_TX) {
-        console.log(`[RPC Wallet] Detected low number of transactions confirmed, re-announcing transactions to make sure miners saw them.`)
-        await this.rebroadcastTransactions()
-      }
-    }
+    // // Check to see how many transactions got confirmed
+    // if (startAncestorCount >= MAX_MEMPOOL_ANCESTORS || startAncestorSize >= MAX_MEMPOOL_ANCESTOR_SIZE) {
+    //   // If there are less confirmed than REPAIR_MIN_TX, then rebroadcast the transactions
+    //   if (numberConfirmed < REPAIR_MIN_TX) {
+    //     console.log(`[RPC Wallet] Detected low number of transactions confirmed, re-announcing transactions to make sure miners saw them.`)
+    //     await this.rebroadcastTransactions()
+    //   }
+    // }
 
     // If we had started with maximum ancestors, then log the status
     if (hadMaxAncestors) { console.log(`[RPC Wallet] Unconfirmed count has decreased, resuming sending transactions! | Ancestor Count: ${this.currentAncestorCount} - Ancestor Size: ${(this.currentAncestorSize / ONE_MB).toFixed(2)}MB`) }

--- a/src/modules/wallets/RPCWallet.js
+++ b/src/modules/wallets/RPCWallet.js
@@ -31,8 +31,9 @@ const UPDATE_ANCESTOR_STATUS = 5 * ONE_SECOND
 const REPAIR_ANCESTORS_AFTER = 1 * ONE_MINUTE
 const PEER_CONNECT_LENGTH = 5 * ONE_SECOND
 const REBROADCAST_LENGTH = 30 * ONE_SECOND
-const CONFIRMATION_CHECK_LENGTH = 20 * ONE_SECOND
-const CONFIRMATION_REBROADCAST_DELAY = 1 * ONE_MINUTE
+const CONFIRMATION_CHECK_INTERVAL = 20 * ONE_SECOND
+const CONFIRMATION_CHECK_UPDATE_ANCESTORS_AFTER = 5 * ONE_MINUTE
+const CONFIRMATION_REBROADCAST_DELAY = 2 * ONE_MINUTE
 const REPAIR_MIN_TX = 100
 
 // List of all Wallet-Only RPC Methods
@@ -152,6 +153,7 @@ class RPCWallet {
     this.previousTXOutput = undefined
     this.onConfirmationSubscriptions = {}
     this.onConfirmationInterval = undefined
+    this.lastTXTime = Date.now()
 
     // Initialize our initial peer array
     this.peers = []
@@ -216,6 +218,7 @@ class RPCWallet {
 
     let foundUnconfirmed = false
 
+    let numberConfirmed = 0
     while (!foundUnconfirmed) {
       let txidToCheck = this.unconfirmedTxids[0]
 
@@ -238,12 +241,13 @@ class RPCWallet {
           // Check to make sure if it is not in the mempool, that it at least has one confirmation.
           if (confirmations >= 1) {
             // Since it has a confirmation, remove it from the list!
-            console.log(`Transaction was already Confirmed! Removing it from the list! ${txidToCheck}`)
+            // console.log(`Transaction was already Confirmed! Removing it from the list! ${txidToCheck}`)
+            numberConfirmed++
             this.unconfirmedTransactions.shift()
             this.unconfirmedTxids.shift()
           } else {
             console.error(`TXID not in mempool AND not found! ${txidToCheck}`)
-            return
+            foundUnconfirmed = true
           }
         }
       } else {
@@ -252,6 +256,10 @@ class RPCWallet {
         console.log(`Oldest TX in mempool ${txidToCheck}`)
       }
     }
+
+    console.log(`[RPC Wallet] ${numberConfirmed} Transactions Confirmed!`)
+
+    return numberConfirmed
   }
 
   /**
@@ -260,59 +268,69 @@ class RPCWallet {
    */
   async updateAncestorStatus () {
     console.log('[RPC Wallet] Updating Ancestor Status...')
-    // We next check to see if there are any transactions currently in the mempool that we need to be aware of.
-    // To check the mempool, we start by grabbing the UTXO's to get the txid of the most recent transaction that was sent
-    let utxos = await this.getUTXOs()
+    // Check all transactions still inside of our unconfirmed array
+    await this.checkAllUnconfirmed()
 
-    // Grab the most recent txid
-    let mostRecentUTXO = utxos[0]
-    let mostRecentTXID = mostRecentUTXO.txid
-    // Check to see if the utxo is still in the mempool and if it has ancestors
-    let getMempoolEntry = await this.rpcRequest('getmempoolentry', [ mostRecentTXID ])
-    // Check if we have an error and handle it
-    if (getMempoolEntry.error && getMempoolEntry.error !== null) {
-      // If the error 'Transaction not in mempool' occurs, that means that the most recent transaction
-      // has already recieved a confirmation, so it has no ancestors we need to worry about.
-
-      // If the error is different, than throw it up for further inspection.
-      if (getMempoolEntry.error.message === 'Transaction not in mempool' || getMempoolEntry.error.message === 'Transaction not in mempool.') {
-        // Grab the transaction and check the number of confirmations
-        let checkConfirmations = await this.rpcRequest('getrawtransaction', [ mostRecentTXID, true ])
-
-        // Ignore if there was an error, but set the number of confirmations if available
-        if (checkConfirmations.result && checkConfirmations.result.confirmations) { mostRecentUTXO.confirmations = checkConfirmations.result.confirmations }
-
-        // Check to make sure if it is not in the mempool, that it at least has one confirmation.
-        if (mostRecentUTXO.confirmations >= 1) {
-          // Reset utxo count if the most recent one was confirmed
-          this.currentAncestorCount = 0
-          this.currentAncestorSize = 0
-        } else {
-          // If we have gotten here, that means the transaction has zero confirmations, and is not included in the mempool, and so we need to repair it's chain...
-          console.log(`[RPC Wallet] [WARNING] The most recent unspent transaction has zero confirmations and is not in the mempool! Attempting to repair mempool by rebroadcasting transactions, please wait... (txid: ${mostRecentTXID}) ${JSON.stringify(checkConfirmations)}`)
-          await this.checkAllUnconfirmed()
-          await this.rebroadcastTransactions()
-
-          // Don't update anything, and return for now, so that `updateAncestorStatus` will run again
-          return
-        }
-      } else {
-        // Throw an error if the transaction error is not that it is missing from the mempool.
-        throw new Error('Error grabbing the mempool entry! ' + JSON.stringify(getMempoolEntry.error))
-      }
+    // Using the unconfirmed array, sum up the current Ancestor total
+    this.currentAncestorCount = this.unconfirmedTxids.length
+    this.currentAncestorSize = 0
+    for (let hex of this.unconfirmedTransactions) {
+      this.currentAncestorSize += hex.length
     }
 
-    // If the tx is still in the mempool, it will have results
-    if (getMempoolEntry.result) {
-      let txMempoolStatus = getMempoolEntry.result
+    // // We next check to see if there are any transactions currently in the mempool that we need to be aware of.
+    // // To check the mempool, we start by grabbing the UTXO's to get the txid of the most recent transaction that was sent
+    // let utxos = await this.getUTXOs()
 
-      // Store the current ancestor count & size
-      this.currentAncestorCount = txMempoolStatus.ancestorcount
-      this.currentAncestorSize = txMempoolStatus.ancestorsize
+    // // Grab the most recent txid
+    // let mostRecentUTXO = utxos[0]
+    // let mostRecentTXID = mostRecentUTXO.txid
+    // // Check to see if the utxo is still in the mempool and if it has ancestors
+    // let getMempoolEntry = await this.rpcRequest('getmempoolentry', [ mostRecentTXID ])
+    // // Check if we have an error and handle it
+    // if (getMempoolEntry.error && getMempoolEntry.error !== null) {
+    //   // If the error 'Transaction not in mempool' occurs, that means that the most recent transaction
+    //   // has already recieved a confirmation, so it has no ancestors we need to worry about.
 
-      // Also increase the count by one in order to account for the txid from the mempool
-      this.currentAncestorCount++
-    }
+    //   // If the error is different, than throw it up for further inspection.
+    //   if (getMempoolEntry.error.message === 'Transaction not in mempool' || getMempoolEntry.error.message === 'Transaction not in mempool.') {
+    //     // Grab the transaction and check the number of confirmations
+    //     let checkConfirmations = await this.rpcRequest('getrawtransaction', [ mostRecentTXID, true ])
+
+    //     // Ignore if there was an error, but set the number of confirmations if available
+    //     if (checkConfirmations.result && checkConfirmations.result.confirmations) { mostRecentUTXO.confirmations = checkConfirmations.result.confirmations }
+
+    //     // Check to make sure if it is not in the mempool, that it at least has one confirmation.
+    //     if (mostRecentUTXO.confirmations >= 1) {
+    //       // Reset utxo count if the most recent one was confirmed
+    //       this.currentAncestorCount = 0
+    //       this.currentAncestorSize = 0
+    //     } else {
+    //       // If we have gotten here, that means the transaction has zero confirmations, and is not included in the mempool, and so we need to repair it's chain...
+    //       console.log(`[RPC Wallet] [WARNING] The most recent unspent transaction has zero confirmations and is not in the mempool! Attempting to repair mempool by rebroadcasting transactions, please wait... (txid: ${mostRecentTXID}) ${JSON.stringify(checkConfirmations)}`)
+    //       await this.checkAllUnconfirmed()
+    //       await this.rebroadcastTransactions()
+
+    //       // Don't update anything, and return for now, so that `updateAncestorStatus` will run again
+    //       return
+    //     }
+    //   } else {
+    //     // Throw an error if the transaction error is not that it is missing from the mempool.
+    //     throw new Error('Error grabbing the mempool entry! ' + JSON.stringify(getMempoolEntry.error))
+    //   }
+    // }
+
+    // // If the tx is still in the mempool, it will have results
+    // if (getMempoolEntry.result) {
+    //   let txMempoolStatus = getMempoolEntry.result
+
+    //   // Store the current ancestor count & size
+    //   this.currentAncestorCount = txMempoolStatus.ancestorcount
+    //   this.currentAncestorSize = txMempoolStatus.ancestorsize
+
+    //   // Also increase the count by one in order to account for the txid from the mempool
+    //   this.currentAncestorCount++
+    // }
 
     console.log(`[RPC Wallet] Updated Ancestor Count: ${this.currentAncestorCount} - Updated Ancestor Size: ${(this.currentAncestorSize / ONE_MB).toFixed(2)}MB`) 
 
@@ -324,11 +342,14 @@ class RPCWallet {
    * @param {String} hex - The transaction hex to count
    * @return {Boolean} Returns true on success
    */
-  addAncestor (hex) {
+  async addAncestor (hex) {
     // Increase the ancestor count
     this.currentAncestorCount++
     // Increase the ancestor size (byte length)
     this.currentAncestorSize += Buffer.from(hex, 'hex').length
+
+    // Every 100 force update the current ancestor status
+    if (this.currentAncestorCount % 100 === 0) { await this.checkAncestorCount(true) }
 
     // Log every 25
     if (this.currentAncestorCount % 25 === 0) { console.log(`[RPC Wallet] Updated Ancestor Count: ${this.currentAncestorCount} - Updated Ancestor Size: ${(this.currentAncestorSize / ONE_MB).toFixed(2)}MB`) }
@@ -390,15 +411,13 @@ class RPCWallet {
     }
 
     // Count the number of confirmed
-    let numberConfirmed = startAncestorCount - this.currentAncestorCount
+    // let numberConfirmed = startAncestorCount - this.currentAncestorCount
     // Remove the transactions that just got confirmed
-    for (let i = 0; i < numberConfirmed; i++) {
-      this.unconfirmedTransactions.shift()
-      this.unconfirmedTxids.shift()
-    }
-
-    console.log(`[RPC Wallet] ${numberConfirmed} Transactions Confirmed! (${((startAncestorSize - this.currentAncestorSize) / ONE_MB).toFixed(2)} MB)`)
-
+    // for (let i = 0; i < numberConfirmed; i++) {
+    //   this.unconfirmedTransactions.shift()
+    //   this.unconfirmedTxids.shift()
+    // }
+    let numberConfirmed = await this.checkAllUnconfirmed()
 
     // Check to see how many transactions got confirmed
     if (startAncestorCount >= MAX_MEMPOOL_ANCESTORS || startAncestorSize >= MAX_MEMPOOL_ANCESTOR_SIZE) {
@@ -743,11 +762,11 @@ class RPCWallet {
     // Check if there was an error broadcasting the transaction
     if (broadcastTX.error && broadcastTX.error !== null) { throw new Error('Error broadcasting tx: ' + signedTXHex + '\n' + JSON.stringify(broadcastTX.error)) }
 
-    // Add the tx we just sent to the Ancestor count
-    this.addAncestor(signedTXHex)
     // Add our tx hex to the unconfirmed transactions array
     this.unconfirmedTransactions.push(signedTXHex)
     this.unconfirmedTxids.push(broadcastTX.result)
+    // Add the tx we just sent to the Ancestor count
+    await this.addAncestor(signedTXHex)
 
     // Set the new tx to be used as the next output.
     this.previousTXOutput = {
@@ -755,6 +774,11 @@ class RPCWallet {
       amount: outputs[this.publicAddress],
       vout: 0
     }
+
+    // Mark a timestamp for the last time we have sent a transaction,
+    // this is to allow us to check if we should be running `checkAncestorCount`
+    // inside of the `onConfirmationInterval` check
+    this.lastTXTime = Date.now()
 
     // Return the TXID of the transaction
     return broadcastTX.result
@@ -788,10 +812,15 @@ class RPCWallet {
 
     // If we do not already have a loop going to make sure confirmations get fired off, create one
     if (!this.onConfirmationInterval) {
-      this.onConfirmationInterval = setInterval((async () => { 
-        await this.checkAncestorCount(true)
+      this.onConfirmationInterval = setInterval((async () => {
+        // Only run the checkAncestorCount function IF if has been at least CONFIRMATION_CHECK_UPDATE_ANCESTORS_AFTER
+        // since the last transaction was sent
+        if (Date.now() - this.lastTXTime > CONFIRMATION_CHECK_UPDATE_ANCESTORS_AFTER) { 
+          this.lastTXTime = Date.now()
+          await this.checkAncestorCount(true)
+        }
         await this.checkForConfirmations() 
-      }).bind(this), CONFIRMATION_CHECK_LENGTH)
+      }).bind(this), CONFIRMATION_CHECK_INTERVAL)
     }
   }
 
@@ -848,7 +877,7 @@ class RPCWallet {
 
     while (subCount > 0) {
       console.log(`[RPC Wallet] Waiting for ${Object.keys(this.onConfirmationSubscriptions).length} records to be confirmed! (onConfirmation subscription)`)
-      await new Promise((resolve, reject) => { setTimeout(resolve, CONFIRMATION_CHECK_LENGTH) })
+      await new Promise((resolve, reject) => { setTimeout(resolve, 10 * ONE_SECOND) })
       await this.checkAncestorCount(true)
       await this.checkForConfirmations()
 


### PR DESCRIPTION
# Changelog
## Changed
- Changed logic for classifying a transaction as confirmed, it will now query the RPC each transaction explicitly
- Changed Ancestor Count calculation to use internal storage instead of querying the RPC for count
- Decreased maximum Ancestor Size to 1.5MB down from 1.75MB to prevent being "banned" by other nodes on broadcast
- RPCWallet Peers will now stay connected between rebroadcasts to allow them more time to request transactions
- Increased RPCWallet minimum UTXO amount from 0.0001 FLO to 1 FLO
## Fixed
- Fixed calculation of Ancestor Size
- Fixed logging of Peers during a Rebroadcast
- Fixed RPCWallet rebroadcasting of transactions that are unconfirmed